### PR TITLE
Add room and payment admin modules

### DIFF
--- a/tareas/admin/Forms/form_habitacion.py
+++ b/tareas/admin/Forms/form_habitacion.py
@@ -1,0 +1,56 @@
+from django import forms
+from django.utils import timezone
+from tareas.models import Habitaciones, Tiposhabitacion
+
+class HabitacionForm(forms.ModelForm):
+    class Meta:
+        model = Habitaciones
+        fields = ['numero', 'tipohabitacionid', 'capacidad', 'disponible', 'estado', 'fechacreacion']
+        widgets = {
+            'fechacreacion': forms.DateTimeInput(attrs={'type': 'datetime-local'})
+        }
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.fields['estado'] = forms.TypedChoiceField(
+            choices=[(True, 'Activo'), (False, 'Inactivo')],
+            coerce=lambda x: x == 'True',
+            empty_value=None
+        )
+        self.fields['disponible'] = forms.TypedChoiceField(
+            choices=[(True, 'Sí'), (False, 'No')],
+            coerce=lambda x: x == 'True',
+            empty_value=None
+        )
+
+    def save(self, commit=True):
+        obj = super().save(commit=False)
+        if not obj.fechacreacion:
+            obj.fechacreacion = timezone.now()
+        if commit:
+            obj.save()
+        return obj
+
+class TipoHabitacionForm(forms.ModelForm):
+    class Meta:
+        model = Tiposhabitacion
+        fields = ['nombre', 'descripcion', 'costodiario', 'estado', 'fechacreacion']
+        widgets = {
+            'fechacreacion': forms.DateTimeInput(attrs={'type': 'datetime-local'})
+        }
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.fields['estado'] = forms.TypedChoiceField(
+            choices=[(True, 'Activo'), (False, 'Inactivo')],
+            coerce=lambda x: x == 'True',
+            empty_value=None
+        )
+
+    def save(self, commit=True):
+        obj = super().save(commit=False)
+        if not obj.fechacreacion:
+            obj.fechacreacion = timezone.now()
+        if commit:
+            obj.save()
+        return obj

--- a/tareas/admin/Forms/form_metodo_pago.py
+++ b/tareas/admin/Forms/form_metodo_pago.py
@@ -1,0 +1,32 @@
+from django import forms
+from django.utils import timezone
+from tareas.models import Metodospago
+
+class MetodoPagoForm(forms.ModelForm):
+    class Meta:
+        model = Metodospago
+        fields = ['nombre', 'descripcion', 'requiereverificacion', 'estado', 'fechacreacion']
+        widgets = {
+            'fechacreacion': forms.DateTimeInput(attrs={'type': 'datetime-local'})
+        }
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.fields['estado'] = forms.TypedChoiceField(
+            choices=[(True, 'Activo'), (False, 'Inactivo')],
+            coerce=lambda x: x == 'True',
+            empty_value=None
+        )
+        self.fields['requiereverificacion'] = forms.TypedChoiceField(
+            choices=[(True, 'Sí'), (False, 'No')],
+            coerce=lambda x: x == 'True',
+            empty_value=None
+        )
+
+    def save(self, commit=True):
+        obj = super().save(commit=False)
+        if not obj.fechacreacion:
+            obj.fechacreacion = timezone.now()
+        if commit:
+            obj.save()
+        return obj

--- a/tareas/admin/templates/admin/MenuAdmin.html
+++ b/tareas/admin/templates/admin/MenuAdmin.html
@@ -22,6 +22,8 @@
             <li id="inicio"><i class="bi bi-house-fill"></i> Inicio</li>
             <li><i class="bi bi-people-fill"></i> Gestión de Personal</li>
             <li><i class="bi bi-clipboard2-pulse-fill"></i> Servicios Médicos</li>
+            <li><i class="bi bi-door-closed-fill"></i> Gestión de Habitaciones</li>
+            <li><i class="bi bi-credit-card-2-back-fill"></i> Métodos de Pago</li>
             <li><i class="bi bi-person-lines-fill"></i> Control de Pacientes</li>
             <li><i class="bi bi-hospital"></i> Consultas y Emergencias</li>
             <li><i class="bi bi-cash-coin"></i> Gestión Financiera</li>

--- a/tareas/admin/templates/admin/listar_habitaciones.html
+++ b/tareas/admin/templates/admin/listar_habitaciones.html
@@ -1,0 +1,49 @@
+{% extends 'admin/MenuAdmin.html' %}
+{% load static %}
+
+{% block extra_css %}
+<link rel="stylesheet" href="{% static 'admin/css/listar_personal.css' %}">
+{% endblock %}
+
+{% block title %}Habitaciones - BioSalud{% endblock %}
+
+{% block contenido %}
+<div class="listado-card">
+    <h2>Habitaciones</h2>
+    <div class="top-actions">
+        <a href="{% url 'registrar_habitacion' %}" class="btn-nuevo">+ Nueva habitación</a>
+        <a href="{% url 'listar_tipos_habitacion' %}" class="btn-nuevo">Tipos de habitación</a>
+    </div>
+    <div class="tabla-scroll">
+        <table class="tabla-personal">
+            <thead>
+                <tr>
+                    <th>Número</th>
+                    <th>Tipo</th>
+                    <th>Capacidad</th>
+                    <th>Disponible</th>
+                    <th>Estado</th>
+                    <th>Acciones</th>
+                </tr>
+            </thead>
+            <tbody>
+                {% for h in habitaciones %}
+                <tr>
+                    <td>{{ h.numero }}</td>
+                    <td>{{ h.tipohabitacionid.nombre }}</td>
+                    <td>{{ h.capacidad }}</td>
+                    <td>{{ h.disponible|yesno:"Sí,No" }}</td>
+                    <td class="{{ h.estado|yesno:'activo,inactivo'|lower }}">{{ h.estado|yesno:"Activo,Inactivo" }}</td>
+                    <td>
+                        <a href="{% url 'editar_habitacion' h.habitacionid %}">Editar</a>
+                        <a href="{% url 'eliminar_habitacion' h.habitacionid %}" onclick="return confirm('¿Eliminar esta habitación?');">Eliminar</a>
+                    </td>
+                </tr>
+                {% empty %}
+                <tr><td colspan="6">No hay habitaciones registradas</td></tr>
+                {% endfor %}
+            </tbody>
+        </table>
+    </div>
+</div>
+{% endblock %}

--- a/tareas/admin/templates/admin/listar_metodos_pago.html
+++ b/tareas/admin/templates/admin/listar_metodos_pago.html
@@ -1,0 +1,44 @@
+{% extends 'admin/MenuAdmin.html' %}
+{% load static %}
+
+{% block extra_css %}
+<link rel="stylesheet" href="{% static 'admin/css/listar_personal.css' %}">
+{% endblock %}
+
+{% block title %}Métodos de Pago - BioSalud{% endblock %}
+
+{% block contenido %}
+<div class="listado-card">
+    <h2>Métodos de Pago</h2>
+    <div class="top-actions">
+        <a href="{% url 'registrar_metodo_pago' %}" class="btn-nuevo">+ Nuevo método</a>
+    </div>
+    <div class="tabla-scroll">
+        <table class="tabla-personal">
+            <thead>
+                <tr>
+                    <th>Nombre</th>
+                    <th>Requiere verificación</th>
+                    <th>Estado</th>
+                    <th>Acciones</th>
+                </tr>
+            </thead>
+            <tbody>
+                {% for m in metodos %}
+                <tr>
+                    <td>{{ m.nombre }}</td>
+                    <td>{{ m.requiereverificacion|yesno:"Sí,No" }}</td>
+                    <td class="{{ m.estado|yesno:'activo,inactivo'|lower }}">{{ m.estado|yesno:"Activo,Inactivo" }}</td>
+                    <td>
+                        <a href="{% url 'editar_metodo_pago' m.metodopagoid %}">Editar</a>
+                        <a href="{% url 'eliminar_metodo_pago' m.metodopagoid %}" onclick="return confirm('¿Eliminar este método?');">Eliminar</a>
+                    </td>
+                </tr>
+                {% empty %}
+                <tr><td colspan="4">No hay métodos registrados</td></tr>
+                {% endfor %}
+            </tbody>
+        </table>
+    </div>
+</div>
+{% endblock %}

--- a/tareas/admin/templates/admin/listar_tipos_habitacion.html
+++ b/tareas/admin/templates/admin/listar_tipos_habitacion.html
@@ -1,0 +1,45 @@
+{% extends 'admin/MenuAdmin.html' %}
+{% load static %}
+
+{% block extra_css %}
+<link rel="stylesheet" href="{% static 'admin/css/listar_personal.css' %}">
+{% endblock %}
+
+{% block title %}Tipos de Habitación - BioSalud{% endblock %}
+
+{% block contenido %}
+<div class="listado-card">
+    <h2>Tipos de Habitación</h2>
+    <div class="top-actions">
+        <a href="{% url 'registrar_tipohabitacion' %}" class="btn-nuevo">+ Nuevo tipo</a>
+        <a href="{% url 'listar_habitaciones' %}" class="btn-nuevo">Ver habitaciones</a>
+    </div>
+    <div class="tabla-scroll">
+        <table class="tabla-personal">
+            <thead>
+                <tr>
+                    <th>Nombre</th>
+                    <th>Costo diario</th>
+                    <th>Estado</th>
+                    <th>Acciones</th>
+                </tr>
+            </thead>
+            <tbody>
+                {% for t in tipos %}
+                <tr>
+                    <td>{{ t.nombre }}</td>
+                    <td>{{ t.costodiario }}</td>
+                    <td class="{{ t.estado|yesno:'activo,inactivo'|lower }}">{{ t.estado|yesno:"Activo,Inactivo" }}</td>
+                    <td>
+                        <a href="{% url 'editar_tipohabitacion' t.tipohabitacionid %}">Editar</a>
+                        <a href="{% url 'eliminar_tipohabitacion' t.tipohabitacionid %}" onclick="return confirm('¿Eliminar este tipo?');">Eliminar</a>
+                    </td>
+                </tr>
+                {% empty %}
+                <tr><td colspan="4">No hay tipos registrados</td></tr>
+                {% endfor %}
+            </tbody>
+        </table>
+    </div>
+</div>
+{% endblock %}

--- a/tareas/admin/templates/admin/registrar_habitacion.html
+++ b/tareas/admin/templates/admin/registrar_habitacion.html
@@ -1,0 +1,32 @@
+{% extends 'admin/MenuAdmin.html' %}
+{% load static %}
+
+{% block extra_css %}
+<link rel="stylesheet" href="{% static 'admin/css/registrar_personal.css' %}">
+{% endblock %}
+
+{% block title %}Registrar Habitación - BioSalud{% endblock %}
+
+{% block contenido %}
+<div class="form-card">
+    <h2>Registrar Habitación</h2>
+    {% if messages %}
+    {% for message in messages %}
+    <div class="alert {{ message.tags }}">{{ message }}</div>
+    {% endfor %}
+    {% endif %}
+    <form method="post" class="form-grid">
+        {% csrf_token %}
+        <div class="form-field">{{ form.numero.label_tag }}{{ form.numero }}</div>
+        <div class="form-field">{{ form.tipohabitacionid.label_tag }}{{ form.tipohabitacionid }}</div>
+        <div class="form-field">{{ form.capacidad.label_tag }}{{ form.capacidad }}</div>
+        <div class="form-field">{{ form.disponible.label_tag }}{{ form.disponible }}</div>
+        <div class="form-field">{{ form.estado.label_tag }}{{ form.estado }}</div>
+        <div class="form-field"></div>
+        <div class="form-full">
+            <button type="submit" class="btn-guardar">Guardar</button>
+        </div>
+    </form>
+    <a href="{% url 'listar_habitaciones' %}" class="volver">← Volver al listado</a>
+</div>
+{% endblock %}

--- a/tareas/admin/templates/admin/registrar_metodo_pago.html
+++ b/tareas/admin/templates/admin/registrar_metodo_pago.html
@@ -1,0 +1,31 @@
+{% extends 'admin/MenuAdmin.html' %}
+{% load static %}
+
+{% block extra_css %}
+<link rel="stylesheet" href="{% static 'admin/css/registrar_personal.css' %}">
+{% endblock %}
+
+{% block title %}Registrar Método de Pago - BioSalud{% endblock %}
+
+{% block contenido %}
+<div class="form-card">
+    <h2>Registrar Método de Pago</h2>
+    {% if messages %}
+    {% for message in messages %}
+    <div class="alert {{ message.tags }}">{{ message }}</div>
+    {% endfor %}
+    {% endif %}
+    <form method="post" class="form-grid">
+        {% csrf_token %}
+        <div class="form-field">{{ form.nombre.label_tag }}{{ form.nombre }}</div>
+        <div class="form-field">{{ form.descripcion.label_tag }}{{ form.descripcion }}</div>
+        <div class="form-field">{{ form.requiereverificacion.label_tag }}{{ form.requiereverificacion }}</div>
+        <div class="form-field">{{ form.estado.label_tag }}{{ form.estado }}</div>
+        <div class="form-field"></div>
+        <div class="form-full">
+            <button type="submit" class="btn-guardar">Guardar</button>
+        </div>
+    </form>
+    <a href="{% url 'listar_metodos_pago' %}" class="volver">← Volver al listado</a>
+</div>
+{% endblock %}

--- a/tareas/admin/templates/admin/registrar_tipohabitacion.html
+++ b/tareas/admin/templates/admin/registrar_tipohabitacion.html
@@ -1,0 +1,31 @@
+{% extends 'admin/MenuAdmin.html' %}
+{% load static %}
+
+{% block extra_css %}
+<link rel="stylesheet" href="{% static 'admin/css/registrar_personal.css' %}">
+{% endblock %}
+
+{% block title %}Registrar Tipo de Habitación - BioSalud{% endblock %}
+
+{% block contenido %}
+<div class="form-card">
+    <h2>Registrar Tipo de Habitación</h2>
+    {% if messages %}
+    {% for message in messages %}
+    <div class="alert {{ message.tags }}">{{ message }}</div>
+    {% endfor %}
+    {% endif %}
+    <form method="post" class="form-grid">
+        {% csrf_token %}
+        <div class="form-field">{{ form.nombre.label_tag }}{{ form.nombre }}</div>
+        <div class="form-field">{{ form.descripcion.label_tag }}{{ form.descripcion }}</div>
+        <div class="form-field">{{ form.costodiario.label_tag }}{{ form.costodiario }}</div>
+        <div class="form-field">{{ form.estado.label_tag }}{{ form.estado }}</div>
+        <div class="form-field"></div>
+        <div class="form-full">
+            <button type="submit" class="btn-guardar">Guardar</button>
+        </div>
+    </form>
+    <a href="{% url 'listar_tipos_habitacion' %}" class="volver">← Volver al listado</a>
+</div>
+{% endblock %}

--- a/tareas/admin/urls_admin.py
+++ b/tareas/admin/urls_admin.py
@@ -9,7 +9,10 @@ from .views_admin import (
     listar_servicios, registrar_servicio, editar_servicio,
     eliminar_servicio, historial_paciente, listar_facturas,
     listar_pagos, listar_consultas, detalle_consulta, reportes_estadisticas,
-    control_accesos, configuraciones_generales, descargar_backup
+    control_accesos, configuraciones_generales, descargar_backup,
+    listar_habitaciones, registrar_habitacion, editar_habitacion, eliminar_habitacion,
+    listar_tipos_habitacion, registrar_tipohabitacion, editar_tipohabitacion, eliminar_tipohabitacion,
+    listar_metodos_pago, registrar_metodo_pago, editar_metodo_pago, eliminar_metodo_pago
 )
 
 
@@ -39,6 +42,18 @@ urlpatterns = [
     path('paciente/<int:paciente_id>/historial/', historial_paciente, name='historial_paciente'),
     path('facturas/', listar_facturas, name='listar_facturas'),
     path('pagos/', listar_pagos, name='listar_pagos'),
+    path('habitaciones/', listar_habitaciones, name='listar_habitaciones'),
+    path('habitaciones/nueva/', registrar_habitacion, name='registrar_habitacion'),
+    path('habitaciones/<int:habitacion_id>/editar/', editar_habitacion, name='editar_habitacion'),
+    path('habitaciones/<int:habitacion_id>/eliminar/', eliminar_habitacion, name='eliminar_habitacion'),
+    path('tipos_habitacion/', listar_tipos_habitacion, name='listar_tipos_habitacion'),
+    path('tipos_habitacion/nueva/', registrar_tipohabitacion, name='registrar_tipohabitacion'),
+    path('tipos_habitacion/<int:tipo_id>/editar/', editar_tipohabitacion, name='editar_tipohabitacion'),
+    path('tipos_habitacion/<int:tipo_id>/eliminar/', eliminar_tipohabitacion, name='eliminar_tipohabitacion'),
+    path('metodos_pago/', listar_metodos_pago, name='listar_metodos_pago'),
+    path('metodos_pago/nuevo/', registrar_metodo_pago, name='registrar_metodo_pago'),
+    path('metodos_pago/<int:metodo_id>/editar/', editar_metodo_pago, name='editar_metodo_pago'),
+    path('metodos_pago/<int:metodo_id>/eliminar/', eliminar_metodo_pago, name='eliminar_metodo_pago'),
     path('consultas/', listar_consultas, name='listar_consultas'),
     path('consultas/<int:consulta_id>/', detalle_consulta, name='detalle_consulta'),
     path('reportes/', reportes_estadisticas, name='reportes_estadisticas'),

--- a/tareas/admin/views_admin.py
+++ b/tareas/admin/views_admin.py
@@ -3,11 +3,14 @@ from tareas.admin.Forms.form_personal import PersonalForm, PersonalEditForm
 from tareas.admin.Forms.form_paciente import PacienteForm, PacienteEditForm
 from tareas.admin.Forms.form_especialidad import EspecialidadForm
 from tareas.admin.Forms.form_servicio import ServicioForm
+from tareas.admin.Forms.form_habitacion import HabitacionForm, TipoHabitacionForm
+from tareas.admin.Forms.form_metodo_pago import MetodoPagoForm
 from tareas.admin.Forms.form_config import ConfiguracionForm
 from tareas.admin.config_utils import load_config, save_config
 from tareas.models import (
     Personal, Pacientes, PacienteAudit, Especialidades,
-    Servicios, Facturas, Pagos, Consultas, Consultaservicios
+    Servicios, Facturas, Pagos, Consultas, Consultaservicios,
+    Habitaciones, Tiposhabitacion, Metodospago
 )
 from django.contrib.auth.hashers import make_password
 from django.contrib import messages
@@ -359,6 +362,174 @@ def eliminar_servicio(request, servicio_id):
     servicio.delete()
     messages.success(request, 'Servicio eliminado.')
     return redirect('listar_servicios')
+
+
+# ----------------------------
+# GESTIÓN DE HABITACIONES
+# ----------------------------
+def listar_habitaciones(request):
+    habitaciones = Habitaciones.objects.all()
+    return render(request, 'admin/listar_habitaciones.html', {
+        'habitaciones': habitaciones,
+        'nombre': request.session.get('nombre'),
+        'rol': request.session.get('rol'),
+    })
+
+
+def registrar_habitacion(request):
+    if request.method == 'POST':
+        form = HabitacionForm(request.POST)
+        if form.is_valid():
+            form.save()
+            messages.success(request, 'Habitación guardada correctamente.')
+            return redirect('listar_habitaciones')
+        else:
+            messages.error(request, 'Revisa los campos del formulario.')
+    else:
+        form = HabitacionForm()
+    return render(request, 'admin/registrar_habitacion.html', {
+        'form': form,
+        'nombre': request.session.get('nombre'),
+        'rol': request.session.get('rol'),
+    })
+
+
+def editar_habitacion(request, habitacion_id):
+    habitacion = Habitaciones.objects.get(pk=habitacion_id)
+    if request.method == 'POST':
+        form = HabitacionForm(request.POST, instance=habitacion)
+        if form.is_valid():
+            form.save()
+            messages.success(request, 'Habitación actualizada.')
+            return redirect('listar_habitaciones')
+        else:
+            messages.error(request, 'Revisa los campos del formulario.')
+    else:
+        form = HabitacionForm(instance=habitacion)
+    return render(request, 'admin/registrar_habitacion.html', {
+        'form': form,
+        'nombre': request.session.get('nombre'),
+        'rol': request.session.get('rol'),
+    })
+
+
+def eliminar_habitacion(request, habitacion_id):
+    habitacion = Habitaciones.objects.get(pk=habitacion_id)
+    habitacion.delete()
+    messages.success(request, 'Habitación eliminada.')
+    return redirect('listar_habitaciones')
+
+
+# ----------------------------
+# GESTIÓN DE TIPOS DE HABITACIÓN
+# ----------------------------
+def listar_tipos_habitacion(request):
+    tipos = Tiposhabitacion.objects.all()
+    return render(request, 'admin/listar_tipos_habitacion.html', {
+        'tipos': tipos,
+        'nombre': request.session.get('nombre'),
+        'rol': request.session.get('rol'),
+    })
+
+
+def registrar_tipohabitacion(request):
+    if request.method == 'POST':
+        form = TipoHabitacionForm(request.POST)
+        if form.is_valid():
+            form.save()
+            messages.success(request, 'Tipo de habitación guardado.')
+            return redirect('listar_tipos_habitacion')
+        else:
+            messages.error(request, 'Revisa los campos del formulario.')
+    else:
+        form = TipoHabitacionForm()
+    return render(request, 'admin/registrar_tipohabitacion.html', {
+        'form': form,
+        'nombre': request.session.get('nombre'),
+        'rol': request.session.get('rol'),
+    })
+
+
+def editar_tipohabitacion(request, tipo_id):
+    tipo = Tiposhabitacion.objects.get(pk=tipo_id)
+    if request.method == 'POST':
+        form = TipoHabitacionForm(request.POST, instance=tipo)
+        if form.is_valid():
+            form.save()
+            messages.success(request, 'Tipo de habitación actualizado.')
+            return redirect('listar_tipos_habitacion')
+        else:
+            messages.error(request, 'Revisa los campos del formulario.')
+    else:
+        form = TipoHabitacionForm(instance=tipo)
+    return render(request, 'admin/registrar_tipohabitacion.html', {
+        'form': form,
+        'nombre': request.session.get('nombre'),
+        'rol': request.session.get('rol'),
+    })
+
+
+def eliminar_tipohabitacion(request, tipo_id):
+    tipo = Tiposhabitacion.objects.get(pk=tipo_id)
+    tipo.delete()
+    messages.success(request, 'Tipo de habitación eliminado.')
+    return redirect('listar_tipos_habitacion')
+
+
+# ----------------------------
+# GESTIÓN DE MÉTODOS DE PAGO
+# ----------------------------
+def listar_metodos_pago(request):
+    metodos = Metodospago.objects.all()
+    return render(request, 'admin/listar_metodos_pago.html', {
+        'metodos': metodos,
+        'nombre': request.session.get('nombre'),
+        'rol': request.session.get('rol'),
+    })
+
+
+def registrar_metodo_pago(request):
+    if request.method == 'POST':
+        form = MetodoPagoForm(request.POST)
+        if form.is_valid():
+            form.save()
+            messages.success(request, 'Método de pago guardado.')
+            return redirect('listar_metodos_pago')
+        else:
+            messages.error(request, 'Revisa los campos del formulario.')
+    else:
+        form = MetodoPagoForm()
+    return render(request, 'admin/registrar_metodo_pago.html', {
+        'form': form,
+        'nombre': request.session.get('nombre'),
+        'rol': request.session.get('rol'),
+    })
+
+
+def editar_metodo_pago(request, metodo_id):
+    metodo = Metodospago.objects.get(pk=metodo_id)
+    if request.method == 'POST':
+        form = MetodoPagoForm(request.POST, instance=metodo)
+        if form.is_valid():
+            form.save()
+            messages.success(request, 'Método de pago actualizado.')
+            return redirect('listar_metodos_pago')
+        else:
+            messages.error(request, 'Revisa los campos del formulario.')
+    else:
+        form = MetodoPagoForm(instance=metodo)
+    return render(request, 'admin/registrar_metodo_pago.html', {
+        'form': form,
+        'nombre': request.session.get('nombre'),
+        'rol': request.session.get('rol'),
+    })
+
+
+def eliminar_metodo_pago(request, metodo_id):
+    metodo = Metodospago.objects.get(pk=metodo_id)
+    metodo.delete()
+    messages.success(request, 'Método de pago eliminado.')
+    return redirect('listar_metodos_pago')
 
 
 # ----------------------------

--- a/tareas/static/admin/js/MenuAdmin.js
+++ b/tareas/static/admin/js/MenuAdmin.js
@@ -39,6 +39,10 @@ document.addEventListener("DOMContentLoaded", function () {
                 window.location.href = "/admin/listar_personal/";
             } else if (opcion === "Servicios Médicos") {
                 window.location.href = "/admin/servicios/";
+            } else if (opcion === "Gestión de Habitaciones") {
+                window.location.href = "/admin/habitaciones/";
+            } else if (opcion === "Métodos de Pago") {
+                window.location.href = "/admin/metodos_pago/";
             } else if (opcion === "Control de Pacientes") {
                 window.location.href = "/admin/listar_pacientes/";
             } else if (opcion === "Consultas y Emergencias") {


### PR DESCRIPTION
## Summary
- add forms for habitaciones, tipos, and métodos de pago
- implement views and URLs for managing rooms and payment options
- add templates for listing and registering these new entities
- extend admin menu and JS navigation

## Testing
- `python manage.py check`

------
https://chatgpt.com/codex/tasks/task_e_6843d16cbbbc83318b96be75cd23efe6