### PR TITLE
Add specialties option to admin menu

### DIFF
--- a/tareas/admin/templates/admin/MenuAdmin.html
+++ b/tareas/admin/templates/admin/MenuAdmin.html
@@ -21,6 +21,7 @@
         <ul class="menu">
             <li id="inicio"><i class="bi bi-house-fill"></i> Inicio</li>
             <li><i class="bi bi-people-fill"></i> Gestión de Personal</li>
+            <li><i class="bi bi-journal-medical"></i> Gestión de Especialidades</li>
             <li><i class="bi bi-clipboard2-pulse-fill"></i> Servicios Médicos</li>
             <li><i class="bi bi-door-closed-fill"></i> Gestión de Habitaciones</li>
             <li><i class="bi bi-credit-card-2-back-fill"></i> Métodos de Pago</li>

--- a/tareas/admin/templates/admin/editar_especialidad.html
+++ b/tareas/admin/templates/admin/editar_especialidad.html
@@ -1,0 +1,30 @@
+{% extends 'admin/MenuAdmin.html' %}
+{% load static %}
+
+{% block extra_css %}
+<link rel="stylesheet" href="{% static 'admin/css/registrar_personal.css' %}">
+{% endblock %}
+
+{% block title %}Editar Especialidad - BioSalud{% endblock %}
+
+{% block contenido %}
+<div class="form-card">
+    <h2>Editar Especialidad</h2>
+    {% if messages %}
+    {% for message in messages %}
+    <div class="alert {{ message.tags }}">{{ message }}</div>
+    {% endfor %}
+    {% endif %}
+    <form method="post" class="form-grid">
+        {% csrf_token %}
+        <div class="form-field">{{ form.nombreespecialidad.label_tag }}{{ form.nombreespecialidad }}</div>
+        <div class="form-field">{{ form.descripcion.label_tag }}{{ form.descripcion }}</div>
+        <div class="form-field">{{ form.estado.label_tag }}{{ form.estado }}</div>
+        <div class="form-field"></div>
+        <div class="form-full">
+            <button type="submit" class="btn-guardar">Guardar Cambios</button>
+        </div>
+    </form>
+    <a href="{% url 'listar_especialidades' %}" class="volver">← Volver al listado</a>
+</div>
+{% endblock %}

--- a/tareas/admin/views_admin.py
+++ b/tareas/admin/views_admin.py
@@ -243,33 +243,43 @@ def exportar_pacientes(request):
 # GESTIÓN DE ESPECIALIDADES
 # ----------------------------
 def listar_especialidades(request):
+    """Mostrar todas las especialidades registradas."""
     especialidades = Especialidades.objects.all()
-    return render(request, 'admin/listar_especialidades.html', {
-        'especialidades': especialidades,
-        'nombre': request.session.get('nombre'),
-        'rol': request.session.get('rol'),
-    })
+    return render(
+        request,
+        'admin/listar_especialidades.html',
+        {
+            'especialidades': especialidades,
+            'nombre': request.session.get('nombre'),
+            'rol': request.session.get('rol'),
+        },
+    )
 
 
 def registrar_especialidad(request):
+    """Registrar una nueva especialidad médica."""
     if request.method == 'POST':
         form = EspecialidadForm(request.POST)
         if form.is_valid():
             form.save()
             messages.success(request, 'Especialidad guardada correctamente.')
             return redirect('listar_especialidades')
-        else:
-            messages.error(request, 'Revisa los campos del formulario.')
+        messages.error(request, 'Revisa los campos del formulario.')
     else:
         form = EspecialidadForm()
-    return render(request, 'admin/registrar_especialidad.html', {
-        'form': form,
-        'nombre': request.session.get('nombre'),
-        'rol': request.session.get('rol'),
-    })
+    return render(
+        request,
+        'admin/registrar_especialidad.html',
+        {
+            'form': form,
+            'nombre': request.session.get('nombre'),
+            'rol': request.session.get('rol'),
+        },
+    )
 
 
 def editar_especialidad(request, especialidad_id):
+    """Editar los datos de una especialidad médica."""
     especialidad = Especialidades.objects.get(pk=especialidad_id)
     if request.method == 'POST':
         form = EspecialidadForm(request.POST, instance=especialidad)
@@ -281,7 +291,8 @@ def editar_especialidad(request, especialidad_id):
             messages.error(request, 'Revisa los campos del formulario.')
     else:
         form = EspecialidadForm(instance=especialidad)
-    return render(request, 'admin/registrar_especialidad.html', {
+
+    return render(request, 'admin/editar_especialidad.html', {
         'form': form,
         'nombre': request.session.get('nombre'),
         'rol': request.session.get('rol'),

--- a/tareas/static/admin/js/MenuAdmin.js
+++ b/tareas/static/admin/js/MenuAdmin.js
@@ -37,6 +37,8 @@ document.addEventListener("DOMContentLoaded", function () {
                 `;
             } else if (opcion === "Gestión de Personal") {
                 window.location.href = "/admin/listar_personal/";
+            } else if (opcion === "Gestión de Especialidades") {
+                window.location.href = "/admin/especialidades/";
             } else if (opcion === "Servicios Médicos") {
                 window.location.href = "/admin/servicios/";
             } else if (opcion === "Gestión de Habitaciones") {


### PR DESCRIPTION
## Summary
- add 'Gestión de Especialidades' item in `MenuAdmin.html`
- route new menu option in `MenuAdmin.js`
- add template for editing specialties and use it from the view
- document specialties views

## Testing
- `python manage.py check`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6861e7033d688328835f36271081b617