### PR TITLE
Improve admin action buttons

### DIFF
--- a/tareas/admin/templates/admin/listar_consultas.html
+++ b/tareas/admin/templates/admin/listar_consultas.html
@@ -36,7 +36,7 @@
                     <td>{{ c.personalid.nombres }} {{ c.personalid.apellidos }}</td>
                     <td>{{ c.motivocita }}</td>
                     <td>{{ c.costo }}</td>
-                    <td><a href="{% url 'detalle_consulta' c.consultaid %}">Detalles</a></td>
+                    <td><a href="{% url 'detalle_consulta' c.consultaid %}" class="action-icon view" title="Detalles"><i class="bi bi-info-circle"></i></a></td>
                 </tr>
                 {% empty %}
                 <tr><td colspan="6">No hay consultas registradas</td></tr>

--- a/tareas/admin/templates/admin/listar_especialidades.html
+++ b/tareas/admin/templates/admin/listar_especialidades.html
@@ -30,8 +30,8 @@
                     <td>{{ e.descripcion }}</td>
                     <td class="{{ e.estado|yesno:'activo,inactivo'|lower }}">{{ e.estado|yesno:"Activo,Inactivo" }}</td>
                     <td>
-                        <a href="{% url 'editar_especialidad' e.especialidadid %}">Editar</a>
-                        <a href="{% url 'eliminar_especialidad' e.especialidadid %}" onclick="return confirm('¿Eliminar esta especialidad?');">Eliminar</a>
+                        <a href="{% url 'editar_especialidad' e.especialidadid %}" class="action-icon edit" title="Editar"><i class="bi bi-pencil-square"></i></a>
+                        <a href="{% url 'eliminar_especialidad' e.especialidadid %}" class="action-icon delete" title="Eliminar" onclick="return confirm('¿Eliminar esta especialidad?');"><i class="bi bi-trash-fill"></i></a>
                     </td>
                 </tr>
                 {% empty %}

--- a/tareas/admin/templates/admin/listar_habitaciones.html
+++ b/tareas/admin/templates/admin/listar_habitaciones.html
@@ -35,8 +35,8 @@
                     <td>{{ h.disponible|yesno:"Sí,No" }}</td>
                     <td class="{{ h.estado|yesno:'activo,inactivo'|lower }}">{{ h.estado|yesno:"Activo,Inactivo" }}</td>
                     <td>
-                        <a href="{% url 'editar_habitacion' h.habitacionid %}">Editar</a>
-                        <a href="{% url 'eliminar_habitacion' h.habitacionid %}" onclick="return confirm('¿Eliminar esta habitación?');">Eliminar</a>
+                        <a href="{% url 'editar_habitacion' h.habitacionid %}" class="action-icon edit" title="Editar"><i class="bi bi-pencil-square"></i></a>
+                        <a href="{% url 'eliminar_habitacion' h.habitacionid %}" class="action-icon delete" title="Eliminar" onclick="return confirm('¿Eliminar esta habitación?');"><i class="bi bi-trash-fill"></i></a>
                     </td>
                 </tr>
                 {% empty %}

--- a/tareas/admin/templates/admin/listar_metodos_pago.html
+++ b/tareas/admin/templates/admin/listar_metodos_pago.html
@@ -30,8 +30,8 @@
                     <td>{{ m.requiereverificacion|yesno:"Sí,No" }}</td>
                     <td class="{{ m.estado|yesno:'activo,inactivo'|lower }}">{{ m.estado|yesno:"Activo,Inactivo" }}</td>
                     <td>
-                        <a href="{% url 'editar_metodo_pago' m.metodopagoid %}">Editar</a>
-                        <a href="{% url 'eliminar_metodo_pago' m.metodopagoid %}" onclick="return confirm('¿Eliminar este método?');">Eliminar</a>
+                        <a href="{% url 'editar_metodo_pago' m.metodopagoid %}" class="action-icon edit" title="Editar"><i class="bi bi-pencil-square"></i></a>
+                        <a href="{% url 'eliminar_metodo_pago' m.metodopagoid %}" class="action-icon delete" title="Eliminar" onclick="return confirm('¿Eliminar este método?');"><i class="bi bi-trash-fill"></i></a>
                     </td>
                 </tr>
                 {% empty %}

--- a/tareas/admin/templates/admin/listar_pacientes.html
+++ b/tareas/admin/templates/admin/listar_pacientes.html
@@ -57,13 +57,13 @@
                     <td>{{ p.gruposanguineo }}</td>
                     <td class="{{ p.estado|yesno:'activo,inactivo'|lower }}">{{ p.estado|yesno:"Activo,Inactivo" }}</td>
                     <td>
-                        <a href="{% url 'ver_paciente' p.pacienteid %}">Ver</a>
-                        <a href="{% url 'historial_paciente' p.pacienteid %}">Historial</a>
-                        <a href="{% url 'editar_paciente' p.pacienteid %}">Editar</a>
+                        <a href="{% url 'ver_paciente' p.pacienteid %}" class="action-icon view" title="Ver"><i class="bi bi-eye"></i></a>
+                        <a href="{% url 'historial_paciente' p.pacienteid %}" class="action-icon history" title="Historial"><i class="bi bi-clock-history"></i></a>
+                        <a href="{% url 'editar_paciente' p.pacienteid %}" class="action-icon edit" title="Editar"><i class="bi bi-pencil-square"></i></a>
                         {% if p.estado %}
-                        <a href="{% url 'inactivar_paciente' p.pacienteid %}">Inactivar</a>
+                        <a href="{% url 'inactivar_paciente' p.pacienteid %}" class="action-icon inactivate" title="Inactivar"><i class="bi bi-x-circle"></i></a>
                         {% else %}
-                        <a href="{% url 'reactivar_paciente' p.pacienteid %}">Reactivar</a>
+                        <a href="{% url 'reactivar_paciente' p.pacienteid %}" class="action-icon activate" title="Reactivar"><i class="bi bi-check-circle"></i></a>
                         {% endif %}
                     </td>
                 </tr>

--- a/tareas/admin/templates/admin/listar_personal.html
+++ b/tareas/admin/templates/admin/listar_personal.html
@@ -34,11 +34,11 @@
                     <td>{{ p.rol }}</td>
                     <td class="{{ p.estado|yesno:'activo,inactivo'|lower }}">{{ p.estado|yesno:"Activo,Inactivo" }}</td>
                     <td>
-                        <a href="{% url 'editar_personal' p.personalid %}">Editar</a>
+                        <a href="{% url 'editar_personal' p.personalid %}" class="action-icon edit" title="Editar"><i class="bi bi-pencil-square"></i></a>
                         {% if p.estado %}
-                        <a href="{% url 'inactivar_personal' p.personalid %}">Inactivar</a>
+                        <a href="{% url 'inactivar_personal' p.personalid %}" class="action-icon inactivate" title="Inactivar"><i class="bi bi-x-circle"></i></a>
                         {% else %}
-                        <a href="{% url 'reactivar_personal' p.personalid %}">Reactivar</a>
+                        <a href="{% url 'reactivar_personal' p.personalid %}" class="action-icon activate" title="Reactivar"><i class="bi bi-check-circle"></i></a>
                         {% endif %}
                     </td>
                 </tr>

--- a/tareas/admin/templates/admin/listar_servicios.html
+++ b/tareas/admin/templates/admin/listar_servicios.html
@@ -30,8 +30,8 @@
                     <td>{{ s.costo }}</td>
                     <td class="{{ s.estado|yesno:'activo,inactivo'|lower }}">{{ s.estado|yesno:"Activo,Inactivo" }}</td>
                     <td>
-                        <a href="{% url 'editar_servicio' s.servicioid %}">Editar</a>
-                        <a href="{% url 'eliminar_servicio' s.servicioid %}" onclick="return confirm('¿Eliminar este servicio?');">Eliminar</a>
+                        <a href="{% url 'editar_servicio' s.servicioid %}" class="action-icon edit" title="Editar"><i class="bi bi-pencil-square"></i></a>
+                        <a href="{% url 'eliminar_servicio' s.servicioid %}" class="action-icon delete" title="Eliminar" onclick="return confirm('¿Eliminar este servicio?');"><i class="bi bi-trash-fill"></i></a>
                     </td>
                 </tr>
                 {% empty %}

--- a/tareas/admin/templates/admin/listar_tipos_habitacion.html
+++ b/tareas/admin/templates/admin/listar_tipos_habitacion.html
@@ -31,8 +31,8 @@
                     <td>{{ t.costodiario }}</td>
                     <td class="{{ t.estado|yesno:'activo,inactivo'|lower }}">{{ t.estado|yesno:"Activo,Inactivo" }}</td>
                     <td>
-                        <a href="{% url 'editar_tipohabitacion' t.tipohabitacionid %}">Editar</a>
-                        <a href="{% url 'eliminar_tipohabitacion' t.tipohabitacionid %}" onclick="return confirm('¿Eliminar este tipo?');">Eliminar</a>
+                        <a href="{% url 'editar_tipohabitacion' t.tipohabitacionid %}" class="action-icon edit" title="Editar"><i class="bi bi-pencil-square"></i></a>
+                        <a href="{% url 'eliminar_tipohabitacion' t.tipohabitacionid %}" class="action-icon delete" title="Eliminar" onclick="return confirm('¿Eliminar este tipo?');"><i class="bi bi-trash-fill"></i></a>
                     </td>
                 </tr>
                 {% empty %}

--- a/tareas/admin/templates/admin/ver_paciente.html
+++ b/tareas/admin/templates/admin/ver_paciente.html
@@ -20,7 +20,7 @@
         <tr><th>Alergias</th><td>{{ paciente.alergias }}</td></tr>
         <tr><th>Observaciones</th><td>{{ paciente.observaciones }}</td></tr>
     </table>
-    <a href="{% url 'historial_paciente' paciente.pacienteid %}" class="volver">Historial</a>
+    <a href="{% url 'historial_paciente' paciente.pacienteid %}" class="action-icon history" title="Historial"><i class="bi bi-clock-history"></i></a>
     <a href="{% url 'listar_pacientes' %}" class="volver">← Volver al listado</a>
 </div>
 {% endblock %}

--- a/tareas/static/admin/css/listar_personal.css
+++ b/tareas/static/admin/css/listar_personal.css
@@ -97,3 +97,23 @@
     color: #a30000;
     border: 1px solid #ff4d4d;
 }
+/* Estilos para iconos de acciones */
+.action-icon {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    width: 30px;
+    height: 30px;
+    margin: 0 2px;
+    border-radius: 4px;
+    color: white;
+    text-decoration: none;
+    font-size: 16px;
+}
+.action-icon.edit { background-color: #0d6efd; }
+.action-icon.delete { background-color: #dc3545; }
+.action-icon.view { background-color: #17a2b8; }
+.action-icon.history { background-color: #6f42c1; }
+.action-icon.inactivate { background-color: #ffc107; color: #000; }
+.action-icon.activate { background-color: #28a745; }
+.action-icon:hover { filter: brightness(1.15); }


### PR DESCRIPTION
## Summary
- add action-icon styles for shaped icon buttons
- replace text actions with icons across admin templates

## Testing
- `python manage.py check` *(fails: ModuleNotFoundError for Django)*

------
https://chatgpt.com/codex/tasks/task_e_68623f8969b4832887585d499b4914a1