### PR TITLE
Add emergency contact fields across patient views

### DIFF
--- a/tareas/admin/Forms/form_paciente.py
+++ b/tareas/admin/Forms/form_paciente.py
@@ -10,8 +10,11 @@ class PacienteForm(forms.ModelForm):
         fields = [
             'nombres', 'apellidos', 'numerodocumento', 'tipodocumento',
             'fechanacimiento', 'edad', 'genero', 'direccion', 'telefono',
+            'nombre_contacto_emergencia', 'telefono_contacto_emergencia',
+            'parentesco_contacto_emergencia',
             'email', 'gruposanguineo', 'alergias',
-            'observaciones', 'estado', 'fecharegistro'
+            'observaciones', 'enfermedades_base', 'idioma_principal',
+            'estado', 'fecharegistro'
         ]
         widgets = {
             'fechanacimiento': forms.DateInput(attrs={'type': 'date'}),
@@ -52,6 +55,10 @@ class PacienteForm(forms.ModelForm):
             'title': 'Solo dígitos'
         })
         self.fields['telefono'].widget.attrs.update({
+            'pattern': r'\d{7,15}',
+            'title': 'Entre 7 y 15 dígitos'
+        })
+        self.fields['telefono_contacto_emergencia'].widget.attrs.update({
             'pattern': r'\d{7,15}',
             'title': 'Entre 7 y 15 dígitos'
         })

--- a/tareas/admin/templates/admin/editar_paciente.html
+++ b/tareas/admin/templates/admin/editar_paciente.html
@@ -27,9 +27,14 @@
         <div class="form-field">{{ form.telefono.label_tag }}{{ form.telefono }}</div>
         <div class="form-field">{{ form.email.label_tag }}{{ form.email }}</div>
         <div class="form-field">{{ form.direccion.label_tag }}{{ form.direccion }}</div>
+        <div class="form-field">{{ form.nombre_contacto_emergencia.label_tag }}{{ form.nombre_contacto_emergencia }}</div>
+        <div class="form-field">{{ form.telefono_contacto_emergencia.label_tag }}{{ form.telefono_contacto_emergencia }}</div>
+        <div class="form-field">{{ form.parentesco_contacto_emergencia.label_tag }}{{ form.parentesco_contacto_emergencia }}</div>
         <div class="form-field">{{ form.gruposanguineo.label_tag }}{{ form.gruposanguineo }}</div>
         <div class="form-field">{{ form.alergias.label_tag }}{{ form.alergias }}</div>
         <div class="form-field">{{ form.observaciones.label_tag }}{{ form.observaciones }}</div>
+        <div class="form-field">{{ form.enfermedades_base.label_tag }}{{ form.enfermedades_base }}</div>
+        <div class="form-field">{{ form.idioma_principal.label_tag }}{{ form.idioma_principal }}</div>
         <div class="form-field">{{ form.estado.label_tag }}{{ form.estado }}</div>
         <div class="form-field"></div>
         <div class="form-full">

--- a/tareas/admin/templates/admin/ver_paciente.html
+++ b/tareas/admin/templates/admin/ver_paciente.html
@@ -16,9 +16,14 @@
         <tr><th>Sexo</th><td>{{ paciente.genero }}</td></tr>
         <tr><th>Dirección</th><td>{{ paciente.direccion }}</td></tr>
         <tr><th>Teléfono</th><td>{{ paciente.telefono }}</td></tr>
+        <tr><th>Contacto Emergencia</th><td>{{ paciente.nombre_contacto_emergencia }}</td></tr>
+        <tr><th>Tel. Emergencia</th><td>{{ paciente.telefono_contacto_emergencia }}</td></tr>
+        <tr><th>Parentesco</th><td>{{ paciente.parentesco_contacto_emergencia }}</td></tr>
         <tr><th>Grupo sanguíneo</th><td>{{ paciente.gruposanguineo }}</td></tr>
         <tr><th>Alergias</th><td>{{ paciente.alergias }}</td></tr>
         <tr><th>Observaciones</th><td>{{ paciente.observaciones }}</td></tr>
+        <tr><th>Enfermedades Base</th><td>{{ paciente.enfermedades_base }}</td></tr>
+        <tr><th>Idioma Principal</th><td>{{ paciente.idioma_principal }}</td></tr>
     </table>
     <a href="{% url 'historial_paciente_admin' paciente.pacienteid %}" class="action-icon history" title="Historial"><i class="bi bi-clock-history"></i> Historial</a>
     <a href="{% url 'listar_pacientes' %}" class="volver">← Volver al listado</a>

--- a/tareas/cajero/templates/cajero/PerfilPaciente.html
+++ b/tareas/cajero/templates/cajero/PerfilPaciente.html
@@ -27,8 +27,13 @@
     <div class="item-perfil"><strong>CI:</strong> {{ paciente.numerodocumento }}</div>
     <div class="item-perfil"><strong>Fecha de Nacimiento:</strong> {{ paciente.fechanacimiento|date:"M. d, Y" }}</div>
     <div class="item-perfil"><strong>Teléfono:</strong> {{ paciente.telefono }}</div>
+    <div class="item-perfil"><strong>Contacto Emergencia:</strong> {{ paciente.nombre_contacto_emergencia }}</div>
+    <div class="item-perfil"><strong>Tel. Emergencia:</strong> {{ paciente.telefono_contacto_emergencia }}</div>
+    <div class="item-perfil"><strong>Parentesco:</strong> {{ paciente.parentesco_contacto_emergencia }}</div>
     <div class="item-perfil"><strong>Dirección:</strong> {{ paciente.direccion }}</div>
     <div class="item-perfil"><strong>Email:</strong> {{ paciente.email }}</div>
+    <div class="item-perfil"><strong>Enfermedades Base:</strong> {{ paciente.enfermedades_base }}</div>
+    <div class="item-perfil"><strong>Idioma Principal:</strong> {{ paciente.idioma_principal }}</div>
 
     <div class="botones-acciones">
       <a href="{% url 'buscar_paciente' %}" class="btn-volver">⟵ Volver al Listado</a>

--- a/tareas/doctor/templates/doctor/PacienteDoctor/PerfilPacienteDoctor.html
+++ b/tareas/doctor/templates/doctor/PacienteDoctor/PerfilPacienteDoctor.html
@@ -54,10 +54,15 @@
         </div>
         <div><strong>Dirección:</strong> {{ paciente.direccion }}</div>
         <div><strong>Teléfono:</strong> {{ paciente.telefono }}</div>
+        <div><strong>Contacto Emergencia:</strong> {{ paciente.nombre_contacto_emergencia }}</div>
+        <div><strong>Tel. Emergencia:</strong> {{ paciente.telefono_contacto_emergencia }}</div>
+        <div><strong>Parentesco:</strong> {{ paciente.parentesco_contacto_emergencia }}</div>
         <div><strong>Email:</strong> {{ paciente.email }}</div>
         <div><strong>Grupo Sanguíneo:</strong> {{ paciente.gruposanguineo }}</div>
         <div><strong>Alergias:</strong> {{ paciente.alergias }}</div>
         <div><strong>Observaciones:</strong> {{ paciente.observaciones }}</div>
+        <div><strong>Enfermedades Base:</strong> {{ paciente.enfermedades_base }}</div>
+        <div><strong>Idioma Principal:</strong> {{ paciente.idioma_principal }}</div>
     </div>
 
     <!-- Fichas clínicas recientes -->

--- a/tareas/enfermeria/templates/enfermeria/Paciente/PerfilPaciente.html
+++ b/tareas/enfermeria/templates/enfermeria/Paciente/PerfilPaciente.html
@@ -52,10 +52,15 @@
             </div>
             <div><strong>Dirección:</strong> {{ paciente.direccion }}</div>
             <div><strong>Teléfono:</strong> {{ paciente.telefono }}</div>
+            <div><strong>Contacto Emergencia:</strong> {{ paciente.nombre_contacto_emergencia }}</div>
+            <div><strong>Tel. Emergencia:</strong> {{ paciente.telefono_contacto_emergencia }}</div>
+            <div><strong>Parentesco:</strong> {{ paciente.parentesco_contacto_emergencia }}</div>
             <div><strong>Email:</strong> {{ paciente.email }}</div>
             <div><strong>Grupo Sanguíneo:</strong> {{ paciente.gruposanguineo }}</div>
             <div><strong>Alergias:</strong> {{ paciente.alergias }}</div>
             <div><strong>Observaciones:</strong> {{ paciente.observaciones }}</div>
+            <div><strong>Enfermedades Base:</strong> {{ paciente.enfermedades_base }}</div>
+            <div><strong>Idioma Principal:</strong> {{ paciente.idioma_principal }}</div>
         </div>
     </div>
 </body>

--- a/tareas/enfermeria/templates/enfermeria/Paciente/RegistrarPaciente/RegistrarPaciente.html
+++ b/tareas/enfermeria/templates/enfermeria/Paciente/RegistrarPaciente/RegistrarPaciente.html
@@ -80,6 +80,15 @@
             <label for="telefono">Teléfono:</label>
             <input type="text" id="telefono" name="telefono" value="{{ paciente.telefono|default:'' }}" pattern="^\d{7,15}$" title="Solo números (mínimo 7 dígitos)">
 
+            <label for="nombre_contacto_emergencia">Nombre Contacto Emergencia:</label>
+            <input type="text" id="nombre_contacto_emergencia" name="nombre_contacto_emergencia" value="{{ paciente.nombre_contacto_emergencia|default:'' }}">
+
+            <label for="telefono_contacto_emergencia">Teléfono Emergencia:</label>
+            <input type="text" id="telefono_contacto_emergencia" name="telefono_contacto_emergencia" value="{{ paciente.telefono_contacto_emergencia|default:'' }}" pattern="^\d{7,15}$" title="Solo números (mínimo 7 dígitos)">
+
+            <label for="parentesco_contacto_emergencia">Parentesco Emergencia:</label>
+            <input type="text" id="parentesco_contacto_emergencia" name="parentesco_contacto_emergencia" value="{{ paciente.parentesco_contacto_emergencia|default:'' }}">
+
             <label for="email">Email:</label>
             <input type="email" id="email" name="email" value="{{ paciente.email|default:'' }}">
 
@@ -91,6 +100,12 @@
 
             <label for="observaciones">Observaciones:</label>
             <textarea id="observaciones" name="observaciones" rows="3">{{ paciente.observaciones|default:'' }}</textarea>
+
+            <label for="enfermedades_base">Enfermedades Base:</label>
+            <textarea id="enfermedades_base" name="enfermedades_base" rows="2">{{ paciente.enfermedades_base|default:'' }}</textarea>
+
+            <label for="idioma_principal">Idioma Principal:</label>
+            <input type="text" id="idioma_principal" name="idioma_principal" value="{{ paciente.idioma_principal|default:'' }}">
 
             <div class="botones-acciones">
                 <button type="submit" name="accion" value="guardar">

--- a/tareas/enfermeria/views_enfermeria.py
+++ b/tareas/enfermeria/views_enfermeria.py
@@ -72,10 +72,13 @@ def perfil_paciente_enfermeria(request, paciente_id):
     # Query para obtener los detalles del paciente
     with connection.cursor() as cursor:
         cursor.execute("""
-            SELECT 
+            SELECT
                 pacienteid, nombres, apellidos, numerodocumento, tipodocumento,
                 fechanacimiento, edad, genero, direccion, telefono, email,
-                gruposanguineo, alergias, observaciones
+                nombre_contacto_emergencia, telefono_contacto_emergencia,
+                parentesco_contacto_emergencia,
+                gruposanguineo, alergias, observaciones,
+                enfermedades_base, idioma_principal
             FROM pacientes
             WHERE pacienteid = %s
         """, [paciente_id])
@@ -96,9 +99,14 @@ def perfil_paciente_enfermeria(request, paciente_id):
         'direccion': fila[8],
         'telefono': fila[9],
         'email': fila[10],
-        'gruposanguineo': fila[11],
-        'alergias': fila[12],
-        'observaciones': fila[13],
+        'nombre_contacto_emergencia': fila[11],
+        'telefono_contacto_emergencia': fila[12],
+        'parentesco_contacto_emergencia': fila[13],
+        'gruposanguineo': fila[14],
+        'alergias': fila[15],
+        'observaciones': fila[16],
+        'enfermedades_base': fila[17],
+        'idioma_principal': fila[18],
     }
 
     return render(request, 'enfermeria/Paciente/PerfilPaciente.html', {'paciente': paciente})
@@ -128,9 +136,14 @@ def registrar_paciente_enfermeria(request):
         direccion = request.POST.get('direccion')
         telefono = request.POST.get('telefono')
         email = request.POST.get('email')
+        nombre_contacto_emergencia = request.POST.get('nombre_contacto_emergencia')
+        telefono_contacto_emergencia = request.POST.get('telefono_contacto_emergencia')
+        parentesco_contacto_emergencia = request.POST.get('parentesco_contacto_emergencia')
         grupo_sanguineo = request.POST.get('gruposanguineo')
         alergias = request.POST.get('alergias')
         observaciones = request.POST.get('observaciones')
+        enfermedades_base = request.POST.get('enfermedades_base')
+        idioma_principal = request.POST.get('idioma_principal')
 
         # Validación de fecha de nacimiento
         if fecha_nacimiento_str:
@@ -168,13 +181,20 @@ def registrar_paciente_enfermeria(request):
                     UPDATE pacientes SET
                         nombres = %s, apellidos = %s, numerodocumento = %s, tipodocumento = %s,
                         fechanacimiento = %s, edad = %s, genero = %s, direccion = %s,
-                        telefono = %s, email = %s, gruposanguineo = %s,
-                        alergias = %s, observaciones = %s
+                        telefono = %s, email = %s,
+                        nombre_contacto_emergencia = %s, telefono_contacto_emergencia = %s,
+                        parentesco_contacto_emergencia = %s,
+                        gruposanguineo = %s, alergias = %s, observaciones = %s,
+                        enfermedades_base = %s, idioma_principal = %s
                     WHERE pacienteid = %s
                 """, [
                     nombres, apellidos, numero_documento, tipo_documento,
                     fecha_nacimiento, edad, genero, direccion,
-                    telefono, email, grupo_sanguineo, alergias, observaciones,
+                    telefono, email,
+                    nombre_contacto_emergencia, telefono_contacto_emergencia,
+                    parentesco_contacto_emergencia,
+                    grupo_sanguineo, alergias, observaciones,
+                    enfermedades_base, idioma_principal,
                     paciente_id
                 ])
             else:
@@ -182,13 +202,19 @@ def registrar_paciente_enfermeria(request):
                     INSERT INTO pacientes (
                         nombres, apellidos, numerodocumento, tipodocumento,
                         fechanacimiento, edad, genero, direccion, telefono,
-                        email, gruposanguineo, alergias, observaciones,
+                        email, nombre_contacto_emergencia, telefono_contacto_emergencia,
+                        parentesco_contacto_emergencia,
+                        gruposanguineo, alergias, observaciones,
+                        enfermedades_base, idioma_principal,
                         fecharegistro, estado
-                    ) VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, CURRENT_TIMESTAMP, TRUE)
+                    ) VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, CURRENT_TIMESTAMP, TRUE)
                 """, [
                     nombres, apellidos, numero_documento, tipo_documento,
                     fecha_nacimiento, edad, genero, direccion,
-                    telefono, email, grupo_sanguineo, alergias, observaciones
+                    telefono, email, nombre_contacto_emergencia, telefono_contacto_emergencia,
+                    parentesco_contacto_emergencia,
+                    grupo_sanguineo, alergias, observaciones,
+                    enfermedades_base, idioma_principal
                 ])
 
         if is_ajax:
@@ -203,7 +229,10 @@ def registrar_paciente_enfermeria(request):
             cursor.execute("""
                 SELECT nombres, apellidos, numerodocumento, tipodocumento,
                        fechanacimiento, edad, genero, direccion, telefono,
-                       email, gruposanguineo, alergias, observaciones
+                       email, nombre_contacto_emergencia, telefono_contacto_emergencia,
+                       parentesco_contacto_emergencia,
+                       gruposanguineo, alergias, observaciones,
+                       enfermedades_base, idioma_principal
                 FROM pacientes
                 WHERE pacienteid = %s
             """, [paciente_id])
@@ -221,9 +250,14 @@ def registrar_paciente_enfermeria(request):
                     'direccion': fila[7],
                     'telefono': fila[8],
                     'email': fila[9],
-                    'gruposanguineo': fila[10],
-                    'alergias': fila[11],
-                    'observaciones': fila[12]
+                    'nombre_contacto_emergencia': fila[10],
+                    'telefono_contacto_emergencia': fila[11],
+                    'parentesco_contacto_emergencia': fila[12],
+                    'gruposanguineo': fila[13],
+                    'alergias': fila[14],
+                    'observaciones': fila[15],
+                    'enfermedades_base': fila[16],
+                    'idioma_principal': fila[17]
                 }
 
     return render(request, 'enfermeria/Paciente/RegistrarPaciente/RegistrarPaciente.html', {


### PR DESCRIPTION
## Summary
- extend `PacienteForm` to include emergency contact and medical info
- update admin templates to edit and view new patient details
- modify enfermeria patient views and templates to manage new columns
- display new patient data for doctor and cashier roles

## Testing
- `python3 manage.py check` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_6863a89b90848328a9baf93215c6c6dc